### PR TITLE
NUS-3264: fdocker agent is not auto-updating

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -17,6 +17,7 @@ RUN printf "#!/bin/sh\necho N 2" > /sbin/runlevel \
  && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i 's/raspberry/docker/g' /opt/domotz/etc/domotz.env
+RUN sed -i 's/debian/docker/g' /opt/domotz/etc/domotz.env
 
 RUN mkdir /opt/utils
 COPY runme.sh /opt/utils


### PR DESCRIPTION
fix the issue to make auto_updating work with changing the agent platform from debian to docker