### PR TITLE
NUS-3832: Docker Image of Domotz Agent based on Ubuntu 22.04 

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL maintainer="devops@domotz.com"
 


### PR DESCRIPTION
Update Dockerfile to use Ubuntu 22.4